### PR TITLE
Screen State Entity

### DIFF
--- a/vhdl/screen-state/screen_state.vhdl
+++ b/vhdl/screen-state/screen_state.vhdl
@@ -1,0 +1,35 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+----- Screen State Entity -----
+--
+-- The inputs of the screen state entity processes the score and
+-- tells the display what "buffer" to show. Each buffer is either a
+-- variable or static screen determined by paddle position, ball position,
+-- or player score.
+--
+-- state:   00 - Game State:    Determined by paddle and ball position, updated from the register.
+--          01 - P1 Won:        Shows a static screen that displays a win msg for P1.
+--          10 - P2 Won:        Shows a static screen that displays a win msg for P2.
+--          11 - Reset State:   Shows an empty static screen.
+--
+entity screen_state is
+    port (
+        reset:      in std_logic;
+        p1_score:   in std_logic_vector(2 downto 0);
+        p2_score:   in std_logic_vector(2 downto 0);
+        state:      out std_logic_vector(1 downto 0)
+    );
+end entity;
+
+-- The following architecture relies on a unary AND operator only available beyond VHDL-2008.
+architecture screen_state_behav of screen_state is
+    signal p1_won : std_logic;
+    signal p2_won : std_logic;
+begin
+    p1_won <= OR p1_score;
+    p2_won <= OR p2_score;
+
+    state(0) <= reset OR p1_won;
+    state(1) <= reset OR p2_won;
+end architecture;

--- a/vhdl/screen-state/screen_state.vhdl
+++ b/vhdl/screen-state/screen_state.vhdl
@@ -27,8 +27,8 @@ architecture screen_state_behav of screen_state is
     signal p1_won : std_logic;
     signal p2_won : std_logic;
 begin
-    p1_won <= OR p1_score;
-    p2_won <= OR p2_score;
+    p1_won <= AND p1_score;
+    p2_won <= AND p2_score;
 
     state(0) <= reset OR p1_won;
     state(1) <= reset OR p2_won;

--- a/vhdl/screen-state/screen_state.vhdl
+++ b/vhdl/screen-state/screen_state.vhdl
@@ -22,7 +22,7 @@ entity screen_state is
     );
 end entity;
 
--- The following architecture relies on a unary AND operator only available beyond VHDL-2008.
+-- The following architecture relies on a unary OR operator only available beyond VHDL-2008.
 architecture screen_state_behav of screen_state is
     signal p1_won : std_logic;
     signal p2_won : std_logic;

--- a/vhdl/screen-state/screen_state_tb.vhdl
+++ b/vhdl/screen-state/screen_state_tb.vhdl
@@ -1,0 +1,62 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity screen_state_tb is
+end screen_state_tb;
+
+architecture behav of screen_state_tb is
+    component screen_state
+        port (  reset:                  in std_logic;
+                p1_score, p2_score:     in std_logic_vector(2 downto 0);
+                state:                  out std_logic_vector(1 downto 0));
+    end component;
+
+    signal reset : std_logic;
+    signal p1_score, p2_score : std_logic_vector(2 downto 0);
+    signal state : std_logic_vector(1 downto 0);
+begin
+    screen_state_0 : screen_state 
+        port map(reset=>reset, p1_score=>p1_score, p2_score=>p2_score, state=>state);
+
+    process
+    begin
+        reset <= '1';
+        p1_score <= "000";
+        p2_score <= "000";
+        wait for 1 ns;
+        assert state = "11"
+            report "bad reset state" severity error;
+
+        reset <= '1';
+        wait for 1 ns;
+        assert state = "11"
+            report "bad reset state" severity error;
+
+        reset <= '0';
+        p1_score <= "000";
+        p2_score <= "000";
+        wait for 1 ns;
+        assert state = "00"
+            report "bad default state" severity error;
+
+        p1_score <= "010";
+        p2_score <= "101";
+        wait for 1 ns;
+        assert state = "00"
+            report "bad default state" severity error;
+
+        p1_score <= "111";
+        p2_score <= "101";
+        wait for 1 ns;
+        assert state = "01"
+            report "bad player_1 won state" severity error;
+
+        p1_score <= "110";
+        p2_score <= "111";
+        wait for 1 ns;
+        assert state = "10"
+            report "bad player_2 won state" severity error;
+
+        wait;
+    end process;
+end behav;


### PR DESCRIPTION
This entity is for turning game data into screen states for the Minecraft display to use. Depending on the player's score and reset signal, a specific state will represented what the display should be "rendering" (what screen buffer the display will use).